### PR TITLE
Add support for generating multiple repos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Run setup
       run: ./setup.sh
     - name: Create new user
-      run: ./newuser.sh
+      run: ./newuser.sh run -test
     - name: Tidy
       run: go mod tidy
     - name: Verify commit is clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - PLAYWITHGODEV_KEY_FILE
 
   gitea:
-    image: gitea/gitea:1.11.5
+    image: gitea/gitea:1.12.0-rc1
     container_name: playwithgodev_gitea
     networks:
       gitea:

--- a/flag.go
+++ b/flag.go
@@ -28,7 +28,7 @@ func main1() int {
 	r.rootCmd = newRootCmd()
 	r.waitCmd = newWaitCmd()
 	r.preCmd = newPreCmd()
-	r.newUserCmd = newInitCmd()
+	r.newUserCmd = newNewUserCmd()
 
 	err := r.mainerr()
 	if err == nil {
@@ -157,12 +157,18 @@ func (g *preCmd) usageErr(format string, args ...interface{}) usageErr {
 type newUserCmd struct {
 	fs           *flag.FlagSet
 	flagDefaults string
+	fNumRepos    *int
+	fUsername    *string
+	fTest        *bool
 }
 
-func newInitCmd() *newUserCmd {
+func newNewUserCmd() *newUserCmd {
 	res := &newUserCmd{}
 	res.flagDefaults = newFlagSet("gitea init", func(fs *flag.FlagSet) {
 		res.fs = fs
+		res.fNumRepos = fs.Int("repos", 1, "how many repos to create")
+		res.fUsername = fs.String("username", "gopher", "the user for which to create the repositories")
+		res.fTest = fs.Bool("test", false, "generate additional test script (only valid in raw mode)")
 	})
 	return res
 }

--- a/internal/ci/workflows.cue
+++ b/internal/ci/workflows.cue
@@ -46,7 +46,7 @@ test: json.#Workflow & {
 			run:  "./setup.sh"
 		}, {
 			name: "Create new user"
-			run:  "./newuser.sh"
+			run:  "./newuser.sh run -test"
 		}, {
 			name: "Tidy"
 			run:  "go mod tidy"

--- a/newuser.sh
+++ b/newuser.sh
@@ -2,4 +2,31 @@
 
 set -eu
 
-go run -exec "go run mvdan.cc/dockexec buildpack-deps@sha256:ec0e9539673254d0cb1db0de347905cdb5d5091df95330f650be071a7e939420 --network=gitea_gitea --rm -e PLAYWITHGODEV_ROOT_USER -e PLAYWITHGODEV_ROOT_PASSWORD -e PLAYWITHGODEV_GITHUB_USER -e PLAYWITHGODEV_GITHUB_PAT" . newuser
+if [ "$#" -eq 0 ]
+then
+	echo "need a command, either run or echo"
+	exit 1
+fi
+
+command="$1"
+shift
+
+if [ "$command" != "run" ] && [ "$command" != "echo" ]
+then
+	echo "unknown command; should be either run or echo"
+	exit 1
+fi
+
+tf=$(mktemp tmpXXXXXX.sh)
+trap "rm -f $tf" EXIT
+
+go run -exec "go run mvdan.cc/dockexec buildpack-deps@sha256:ec0e9539673254d0cb1db0de347905cdb5d5091df95330f650be071a7e939420 --network=gitea_gitea --rm -e PLAYWITHGODEV_ROOT_USER -e PLAYWITHGODEV_ROOT_PASSWORD -e PLAYWITHGODEV_GITHUB_USER -e PLAYWITHGODEV_GITHUB_PAT" . newuser "$@" raw > $tf
+
+chmod 700 $tf
+
+if [ "$command" == "run" ]
+then
+	docker run --rm -e USER_UID=$(id -u) -e USER_GID=$(id -g) --network gitea_gitea -v $PWD:/scripts playwithgo/go1.14.3@sha256:6289a34af0112146e551790d9f2a36622e083600752a02d36f1ad1f9e1389382 /scripts/$(basename $tf)
+else
+	cat $tf
+fi


### PR DESCRIPTION
Also:

* convert gitea to a command that can be a prestep for a guide
* support different output modes, include a -test flag for generating
  test script that can be run as part of CI
* Upgrade to gitea 1.12.0
* Shift usernames to be base32, lowercase (to remove any ambiguity in
  repo names/resolution)