### PR TITLE
Use github.com/myitcv/docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /gitea
+/.bin

--- a/_scripts/common.bash
+++ b/_scripts/common.bash
@@ -1,13 +1,3 @@
-# Create a temporary docker-compose script and update PATH
-td=$(mktemp -d)
-# trap "rm -rf $td" EXIT
-dc=$(which docker-compose)
-cat <<EOD > $td/docker-compose
-#!/usr/bin/env bash
-
-$dc -f docker-compose.yml -f docker-compose-playwithgo.yml "\$@"
-EOD
-chmod +x $td/docker-compose
-export PATH="$td:$PATH"
-
+root="$( command cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../"
+export COMPOSE_FILE="${COMPOSE_FILE:-}:$root/docker-compose.yml:$root/docker-compose-playwithgo.yml"
 dockexec="go run mvdan.cc/dockexec -compose playwithgo -e PLAYWITHGODEV_ROOT_USER -e PLAYWITHGODEV_ROOT_PASSWORD -e PLAYWITHGODEV_GITHUB_USER -e PLAYWITHGODEV_GITHUB_PAT"

--- a/_scripts/env.sh
+++ b/_scripts/env.sh
@@ -6,4 +6,7 @@ source "$( command cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd 
 
 modRoot="$(go list -m -f {{.Dir}})"
 
+GOBIN=$modRoot/.bin go install github.com/myitcv/docker-compose
+
 $export COMPOSE_PROJECT_NAME gitea
+$export PATH "$modRoot/.bin:$PATH"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cuelang.org/go v0.2.0
 	github.com/google/go-github/v31 v31.0.0
 	github.com/kr/pretty v0.2.0 // indirect
+	github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	gopkg.in/retry.v1 v1.0.3
 	mvdan.cc/dockexec v0.0.0-20200617140021-ca98d4465984

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de h1:D5x39vF5KCwKQaw+OC9ZPiLVHXz3UFw2+psEX+gYcto=
 github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de/go.mod h1:kJun4WP5gFuHZgRjZUWWuH1DTxCtxbHDOIJsudS8jzY=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f h1:pqpnXNqsaw1JN83pfyLCUDZqGn0b+nJ1uYD1/R9aURg=
+github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f/go.mod h1:8FDe0/d1OM678ejROLq0oqBo9YsnReTK7jcnJ3a88Ck=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -112,6 +114,8 @@ github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjI
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.5.2 h1:qLvObTrvO/XRCqmkKxUlOBc48bI3efyDuAZe25QiF0w=
 github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.6.0 h1:IZRgg4sfrDH7nsAD1Y/Nwj+GzIfEwpJSLjCaNC3SbsI=
+github.com/rogpeppe/go-internal v1.6.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/testscript v1.1.0 h1:NxTsoOBQ1zibxf6NDtzrjPbK56hDAteIcOTSINZHtow=
 github.com/rogpeppe/testscript v1.1.0/go.mod h1:lzMlnW8LS56mcdJoQYkrlzqOoTFCOemzt5LusJ93bDM=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -169,6 +173,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/tools.go
+++ b/tools.go
@@ -4,5 +4,6 @@ package tools
 
 import (
 	_ "cuelang.org/go/cmd/cue"
+	_ "github.com/myitcv/docker-compose"
 	_ "mvdan.cc/dockexec"
 )


### PR DESCRIPTION
Using github.com/myitcv/docker-compose simplifies the use of
docker-compose in this project, but also enables other projects to
compose this docker-compose.yml into their own setups.

As part of this we ensure that the _scripts/setup.sh script can be run
in the context of another project. The other project does that by
setting COMPOSE_FILE to the "environment" of compose config files, a
list that can be extended by any call to docker-compose using the -f
flag.