### PR TITLE
docker-compose: simplify network setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ version: "3.2"
 networks:
   gitea:
     external: false
-  gitea_impl:
-    external: false
 
 volumes:
   gitea:
@@ -18,8 +16,6 @@ services:
       - ./nginx.sh:/run.sh:ro
     command: ["bash", "/run.sh"]
     networks:
-      gitea_impl:
-
       gitea:
         aliases:
           - play-with-go.dev
@@ -32,9 +28,7 @@ services:
   gitea:
     image: gitea/gitea:1.12.1
     networks:
-      gitea_impl:
-        aliases:
-          - giteaserver
+      - gitea
     environment:
       - USER_UID=1000
       - USER_GID=1000


### PR DESCRIPTION
When used as part of PWG, the gitea services will be added to another
network that forms the backend (the nginx instance will be an alias for
play-with-go.dev there too). However for the testing of the gitea setup
itself (and indeed the setup step) we retain another network (required
because we need to alias the nginx instance and that can only be done in
a user defined network)