### PR TITLE
Hex-encode user and repo names for clarity

### DIFF
--- a/cmd/gitea/main_test.go
+++ b/cmd/gitea/main_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/kr/pretty"
 	"github.com/play-with-go/preguide"
 )
 
@@ -85,6 +87,7 @@ func TestNewUser(t *testing.T) {
 	if err := json.Unmarshal(outJSON, &env); err != nil {
 		t.Fatalf("failed to decode preguide.PrestepOut from %q: %v", outJSON, err)
 	}
+	fmt.Printf("Env vars: %v\n", pretty.Sprint(env))
 }
 
 func (tr *testRunner) mustRunDockerCompose(args ...string) ([]byte, []byte) {

--- a/cmd/gitea/serve.go
+++ b/cmd/gitea/serve.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"encoding/base32"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -171,7 +171,7 @@ func (r *runner) genID() string {
 	bs := make([]byte, binary.MaxVarintLen64)
 	n := binary.PutVarint(bs, diff)
 	var buf bytes.Buffer
-	enc := base32.NewEncoder(base32.HexEncoding, &buf)
+	enc := hex.NewEncoder(&buf)
 	if _, err := enc.Write(bs[:n]); err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	code.gitea.io/sdk/gitea v0.12.1
 	cuelang.org/go v0.2.2
 	github.com/google/go-github/v31 v31.0.0
+	github.com/kr/pretty v0.2.0
 	github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f
 	github.com/play-with-go/preguide v0.0.0-20200813100639-3b9c8943c47f
 	gopkg.in/retry.v1 v1.0.3


### PR DESCRIPTION
base32 encoding means we confuse O with 0 too easily.