### PR TITLE
Use PLAYWITHGO_ROOTCA env var instead of relying on volumes

### DIFF
--- a/_scripts/env.sh
+++ b/_scripts/env.sh
@@ -11,7 +11,7 @@ modRoot="$(go list -m -f {{.Dir}})"
 
 GOBIN=$modRoot/.bin go install github.com/myitcv/docker-compose
 
-rootCA="$(mkcert -CAROOT)/rootCA.pem"
+rootCA="$(cat $(mkcert -CAROOT)/rootCA.pem)"
 $export COMPOSE_PROJECT_NAME gitea
 $export PATH "$modRoot/.bin:$PATH"
-$export MKCERT_CAROOT_CERT "$rootCA"
+$export PLAYWITHGO_ROOTCA "$rootCA"

--- a/_scripts/env_common.bash
+++ b/_scripts/env_common.bash
@@ -1,5 +1,5 @@
 bashExport() {
-	echo export "$1=$2"
+	echo export "$1=\"$2\""
 }
 
 bashAlias() {
@@ -7,7 +7,7 @@ bashAlias() {
 }
 
 smartcdExport() {
-	echo autostash "$1=$2"
+	echo autostash "$1=\"$2\""
 }
 
 smartcdAlias() {
@@ -15,7 +15,7 @@ smartcdAlias() {
 }
 
 githubExport() {
-	echo "::set-env name=$1::$2"
+	echo "::set-env name=$1::$(echo "$2" | sed ':a;N;$!ba;s/%/%25/g' |  sed ':a;N;$!ba;s/\r/%0D/g' | sed ':a;N;$!ba;s/\n/%0A/g')"
 }
 
 githubAlias() {

--- a/docker-compose-playwithgo.yml
+++ b/docker-compose-playwithgo.yml
@@ -4,8 +4,7 @@ services:
   playwithgo:
     environment:
       - PLAYWITHGO_NOGOPHER=true
-    image: playwithgo/go1.15@sha256:7f5fc95e2bd00c13fbf04560d267028db94b7b0b05b4019683517ee1140da384
+      - PLAYWITHGO_ROOTCA
+    image: playwithgo/go1.15@sha256:7bf7788bb2291af0830a8c62cf38e3bfbd8b0d53e5435531458c8f77bd3efaeb
     networks:
       - gitea
-    volumes:
-      - $MKCERT_CAROOT_CERT:/usr/local/share/ca-certificates/${COMPOSE_PROJECT_NAME}_gitea_mkcert.crt:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
 
   gitea_prestep:
-    image: playwithgo/go1.15@sha256:7f5fc95e2bd00c13fbf04560d267028db94b7b0b05b4019683517ee1140da384
+    image: playwithgo/go1.15@sha256:7bf7788bb2291af0830a8c62cf38e3bfbd8b0d53e5435531458c8f77bd3efaeb
     networks:
       - gitea
     command: ["go", "run", "./cmd/gitea", "serve"]
@@ -52,9 +52,9 @@ services:
       - PLAYWITHGODEV_GITHUB_PAT
       - GOPROXY=file:///proxy
       - PLAYWITHGO_NOGOPHER=true
+      - PLAYWITHGO_ROOTCA
     volumes:
       - .:/start
       - $GOMODCACHE/cache/download:/proxy:ro
-      - $MKCERT_CAROOT_CERT:/usr/local/share/ca-certificates/${COMPOSE_PROJECT_NAME}_gitea_mkcert.crt:ro
     working_dir: /start
 


### PR DESCRIPTION
More robust and will work with preguide config