### PR TITLE
cmd/gitea: better handling of random part of repo

### DIFF
--- a/cmd/gitea/main_test.go
+++ b/cmd/gitea/main_test.go
@@ -199,7 +199,7 @@ func waitErr() (err error) {
 
 func prestepErr() (err error) {
 	defer handleKnown(&err)
-	args := strings.NewReader(`{"Repos": [{"Var": "REPO1", "Pattern": "user*"}]}`)
+	args := strings.NewReader(`{"Repos": [{"Var": "REPO1", "Pattern": "user"},{"Var": "REPO2", "Pattern": "user*"}]}`)
 	newuserURL := "http://cmd_gitea:8080/newuser"
 	resp, err := http.Post(newuserURL, "application/json", args)
 	check(err, "failed to post to %v: %v", newuserURL, err)
@@ -229,6 +229,13 @@ func prestepErr() (err error) {
 	}
 	if fail {
 		raise("not all environment variables found")
+	}
+	// Verify that the patterns for both repo were respected
+	if *found["REPO1"] != "user" {
+		raise("expected REPO1 to be %v; got %v", "user", *found["REPO1"])
+	}
+	if *found["REPO2"] == "user" || !strings.HasPrefix(*found["REPO2"], "user") {
+		raise("expected REPO2 to have prefix %v; got %v", "user", *found["REPO2"])
 	}
 	// Test out the user credentials
 	client, err := gitea.NewClient("http://gitea:3000")

--- a/cmd/gitea/serve.go
+++ b/cmd/gitea/serve.go
@@ -206,13 +206,18 @@ repos:
 		var err error
 		var repo *giteasdk.Repository
 		var prefix, suffix string
+		var hasRandomPart bool
 		if i := strings.LastIndex(repoSpec.Pattern, "*"); i != -1 {
+			hasRandomPart = true
 			prefix, suffix = repoSpec.Pattern[:i], repoSpec.Pattern[i+1:]
 		} else {
 			prefix = repoSpec.Pattern
 		}
 		for j := 0; j < 3; j++ {
-			name := prefix + sc.genID() + suffix
+			name := prefix
+			if hasRandomPart {
+				name += sc.genID() + suffix
+			}
 			args := giteasdk.CreateRepoOption{
 				Name:    name,
 				Private: false,
@@ -224,6 +229,9 @@ repos:
 					Repository: repo,
 				})
 				continue repos
+			}
+			if !hasRandomPart {
+				break
 			}
 		}
 		raise("failed to create user repostitory: %v", err)


### PR DESCRIPTION
Usernames that we create by definition have to be random. Repo names now
do not, because they are created within the namespace of a random user.
However, we retain the ability to create random repository names, making
it conditional on the pattern including a '*'.