### PR TITLE
cmd/gitea: serve generated repo as fully qualified path

### DIFF
--- a/cmd/gitea/flag.go
+++ b/cmd/gitea/flag.go
@@ -59,6 +59,9 @@ type rootCmd struct {
 	flagDefaults string
 	fDebug       *bool
 	fRootURL     *string
+
+	// hostname is the parse host from -rootURL
+	hostname string
 }
 
 func newFlagSet(name string, setupFlags func(*flag.FlagSet)) string {

--- a/cmd/gitea/main.go
+++ b/cmd/gitea/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"net/url"
 	"os"
 )
 
@@ -38,6 +39,10 @@ func (r *runner) mainerr() (err error) {
 	if err := r.rootCmd.fs.Parse(os.Args[1:]); err != nil {
 		return usageErr{err, r.rootCmd}
 	}
+
+	u, err := url.Parse(*r.fRootURL)
+	check(err, "failed to parse -rootURL value %q: %v", *r.fRootURL, err)
+	r.rootCmd.hostname = u.Hostname()
 
 	args := r.rootCmd.fs.Args()
 	if len(args) == 0 {

--- a/cmd/gitea/serve.go
+++ b/cmd/gitea/serve.go
@@ -27,6 +27,9 @@ import (
 )
 
 func (sc *serveCmd) run(args []string) error {
+	if len(args) > 0 {
+		raise("serve does not take any flags or arguments")
+	}
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals)
 
@@ -135,7 +138,7 @@ func (sc *serveCmd) newUser(args *gitea.NewUser) preguide.PrestepOut {
 		},
 	}
 	for _, repo := range repos {
-		res.Vars = append(res.Vars, fmt.Sprintf("%v=%v", repo.repoSpec.Var, repo.Name))
+		res.Vars = append(res.Vars, fmt.Sprintf("%v=%v/%v/%v", repo.repoSpec.Var, sc.hostname, user.UserName, repo.Name))
 	}
 	return res
 }
@@ -174,7 +177,7 @@ func (sc *serveCmd) createUser() *userPassword {
 		args := giteasdk.CreateUserOption{
 			FullName:           TemporaryUserFullName,
 			Username:           username,
-			Email:              username + "@gopher.live",
+			Email:              fmt.Sprintf("%v@%v", username, sc.hostname),
 			Password:           password,
 			MustChangePassword: &no,
 		}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,9 @@ services:
   gitea:
     image: gitea/gitea:1.12.5
     networks:
-      - gitea
+      gitea:
+        aliases:
+          - random.com
     environment:
       - USER_UID=1000
       - USER_GID=1000


### PR DESCRIPTION
Currently we only serve the generated repo as the base of the path, e.g.
if the repo is gopher.live/u1234/hello, we return REPO1=hello. This is
not much help, because we are, in the case on no random part, simply
echoing back to the caller the pattern they specified. Furthermore, they
also need to construct the fully qualified path to the repo.

Fix that by returning REPO1=gopher.live/u1234/hello. This also means
that each environment variable returned has some random part to it,
which makes much more sense when we consider the sanitise step.